### PR TITLE
Fix bug in string extension ToRgbComponents

### DIFF
--- a/src/Core/Drawing/Extensions/StringExtensions.cs
+++ b/src/Core/Drawing/Extensions/StringExtensions.cs
@@ -110,7 +110,7 @@ namespace PlatoCore.Drawing.Extensions
             var sb = new StringBuilder();
             sb
                 .Append(r)
-                .Append(b)
+                .Append(g)
                 .Append(b);
 
             // Validate again


### PR DESCRIPTION
Location: PlatoCore.Drawing.Extensions.StringExtensions.ToRgbComponents [113]
Issue: rgb was incorrectly written as rbb
Change: changed the b to g

Not tested due to minimal impact of change.